### PR TITLE
Added healthcheck for mysql container

### DIFF
--- a/three-tier-app/docker-compose.yaml
+++ b/three-tier-app/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   mysql:
     image: mysql:5.6
@@ -12,6 +12,11 @@ services:
       MYSQL_DATABASE: cddb_quintor
       MYSQL_USER: cddb_quintor
       MYSQL_PASSWORD: quintor_pw
+    healthcheck:
+      test: "/usr/bin/mysql --user=$$MYSQL_USER  --password=$$MYSQL_PASSWORD  --execute \"SHOW DATABASES;\""
+      interval: 30s
+      timeout: 10s
+      retries: 5
   cddb_backend:
     depends_on:
       - mysql


### PR DESCRIPTION
Healthcheck is supported since docker-compose version 3, this was
released back in 2017 so it's a safe bet that everyone doing this course
will be on a supported version.
To check if mysql is accepting connections a shell will be used with the
username and password given in the environment, this will run the
command SHOW DATABASES. mysql will return exit code 1 if there is a
problem while executing and 0 if it succeeded.